### PR TITLE
Do not convert _id if it is not a valid ObjectId

### DIFF
--- a/dist/recover-objectid.js
+++ b/dist/recover-objectid.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const ObjectId = require('mongoose').Types.ObjectId;
-
 module.exports = function (mongoose, cachedResults) {
   if (Array.isArray(cachedResults)) {
     const l = cachedResults.length;
@@ -14,17 +12,22 @@ module.exports = function (mongoose, cachedResults) {
   return recoverObjectId(mongoose)(cachedResults);
 };
 
-function isValidObjectId(id) {
-  return ObjectId.isValid(id) && new ObjectId(id).toString() === id;
-}
-
 function recoverObjectId(mongoose) {
   return data => {
-    if (!isValidObjectId(data._id)) {
+    const {
+      ObjectId
+    } = mongoose.Types;
+    const {
+      _id
+    } = data;
+
+    const isValidObjectId = ObjectId.isValid(_id) && new ObjectId(_id).toString() === _id;
+
+    if (!isValidObjectId) {
       return data;
     }
 
-    data._id = new ObjectId(data._id);
+    data._id = new ObjectId(_id);
     return data;
   };
 }

--- a/dist/recover-objectid.js
+++ b/dist/recover-objectid.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const ObjectId = require('mongoose').Types.ObjectId;
+
 module.exports = function (mongoose, cachedResults) {
   if (Array.isArray(cachedResults)) {
     const l = cachedResults.length;
@@ -12,13 +14,17 @@ module.exports = function (mongoose, cachedResults) {
   return recoverObjectId(mongoose)(cachedResults);
 };
 
+function isValidObjectId(id) {
+  return ObjectId.isValid(id) && new ObjectId(id).toString() === id;
+}
+
 function recoverObjectId(mongoose) {
   return data => {
-    if (!data._id) {
+    if (!isValidObjectId(data._id)) {
       return data;
     }
 
-    data._id = new mongoose.Types.ObjectId(data._id);
+    data._id = new ObjectId(data._id);
     return data;
   };
 }

--- a/src/recover-objectid.js
+++ b/src/recover-objectid.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const ObjectId = require('mongoose').Types.ObjectId;
+
 module.exports = function(mongoose, cachedResults) {
   if (Array.isArray(cachedResults)) {
     const l = cachedResults.length;
@@ -10,13 +12,17 @@ module.exports = function(mongoose, cachedResults) {
   return recoverObjectId(mongoose)(cachedResults);
 };
 
+function isValidObjectId(id) {
+  return ObjectId.isValid(id) && new ObjectId(id).toString() === id;
+}
+
 function recoverObjectId(mongoose) {
   return (data) => {
-    if (!data._id) {
+    if (!isValidObjectId(data._id)) {
       return data;
     }
 
-    data._id = new mongoose.Types.ObjectId(data._id);
+    data._id = new ObjectId(data._id);
     return data;
   };
 }

--- a/src/recover-objectid.js
+++ b/src/recover-objectid.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const ObjectId = require('mongoose').Types.ObjectId;
-
 module.exports = function(mongoose, cachedResults) {
   if (Array.isArray(cachedResults)) {
     const l = cachedResults.length;
@@ -12,17 +10,17 @@ module.exports = function(mongoose, cachedResults) {
   return recoverObjectId(mongoose)(cachedResults);
 };
 
-function isValidObjectId(id) {
-  return ObjectId.isValid(id) && new ObjectId(id).toString() === id;
-}
-
 function recoverObjectId(mongoose) {
   return (data) => {
-    if (!isValidObjectId(data._id)) {
+    const { ObjectId } = mongoose.Types;
+    const { _id } = data;
+
+    const isValidObjectId = ObjectId.isValid(_id) && new ObjectId(_id).toString() === _id;
+    if (!isValidObjectId) {
       return data;
     }
 
-    data._id = new ObjectId(data._id);
+    data._id = new ObjectId(_id);
     return data;
   };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,6 @@
 require('should');
 
 const mongoose = require('mongoose');
-const mongodb = require('mongodb');
 const cachegoose = require('../dist');
 const Schema = mongoose.Schema;
 
@@ -22,7 +21,7 @@ describe('cachegoose', () => {
     db.on('open', done);
 
     RecordSchema = new Schema({
-      _id: { type: mongoose.Mixed, default: mongodb.ObjectId },
+      _id: { type: mongoose.Mixed, default: mongoose.Types.ObjectId },
       num: Number,
       str: String,
       date: {

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@
 require('should');
 
 const mongoose = require('mongoose');
+const mongodb = require('mongodb');
 const cachegoose = require('../dist');
 const Schema = mongoose.Schema;
 
@@ -21,6 +22,7 @@ describe('cachegoose', () => {
     db.on('open', done);
 
     RecordSchema = new Schema({
+      _id: { type: mongoose.Mixed, default: mongodb.ObjectId },
       num: Number,
       str: String,
       date: {
@@ -374,6 +376,40 @@ describe('cachegoose', () => {
     const originalConstructor = originalRes[0]._id.constructor.name.should;
     const cachedConstructor = cachedRes[0]._id.constructor.name.should;
     originalConstructor.should.deepEqual(cachedConstructor);
+  });
+
+  it('should return same _id when not ObjectId instance for lean', async () => {
+    const records = [{
+      _id: 'abcdefghijkl',
+      num: 111,
+      str: 'foo'
+    }, {
+      _id: 2,
+      num: 222,
+      str: 'bar'
+    }, {
+      _id: undefined,
+      num: 333,
+      str: 'baz'
+    }, {
+      _id: null,
+      num: 444,
+      str: 'hello'
+    }];
+    await Record.create(records);
+    const originalRes = await getAllLean(60);
+    const cachedRes = await getAllLean(60);
+
+    originalRes.length.should.equal(cachedRes.length);
+    JSON.stringify(originalRes).should.equal(JSON.stringify(cachedRes));
+
+    for (let idx = 0; idx < originalRes.length; idx++) {
+      if (originalRes[idx]._id instanceof mongoose.Types.ObjectId) {
+        const originalConstructor = originalRes[idx]._id.constructor.name.should;
+        const cachedConstructor = cachedRes[idx]._id.constructor.name.should;
+        originalConstructor.should.deepEqual(cachedConstructor);
+      }
+    }
   });
 });
 


### PR DESCRIPTION
Currently, cached lean queries always return ids of ObjectId type, which is ok when using default mongo ids. Issues arise when using custom ids (e.g. strings or numbers). Prior to the changes, ids of all types were being converted to ObjectId, therefore original and cached ids weren't matching.