### PR TITLE
RangeError for large numerical ids with mongoose 6.1.4 when using lean

### DIFF
--- a/dist/recover-objectid.js
+++ b/dist/recover-objectid.js
@@ -21,9 +21,9 @@ function recoverObjectId(mongoose) {
       _id
     } = data;
 
-    const isValidObjectId = ObjectId.isValid(_id) && new ObjectId(_id).toString() === _id;
+    const isSameObjectId = mongoose.isValidObjectId(_id) && new ObjectId(_id).toString() === _id;
 
-    if (!isValidObjectId) {
+    if (!isSameObjectId) {
       return data;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recachegoose",
-  "version": "8.1.1",
+  "version": "8.1.2",
   "description": "Mongoose caching that actually works.",
   "main": "index.js",
   "directories": {
@@ -13,7 +13,7 @@
     "sha1": "^1.1.1"
   },
   "peerDependencies": {
-    "mongoose": "^5.0.1"
+    "mongoose": "^5.0.1" || "^6.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "recachegoose",
-  "version": "8.1.2",
+  "version": "8.1.3",
   "description": "Mongoose caching that actually works.",
   "main": "index.js",
   "directories": {
@@ -13,7 +13,7 @@
     "sha1": "^1.1.1"
   },
   "peerDependencies": {
-    "mongoose": "^5.0.1" || "^6.0.0"
+    "mongoose": "^5.0.1 || ^6.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.10",

--- a/src/recover-objectid.js
+++ b/src/recover-objectid.js
@@ -15,8 +15,8 @@ function recoverObjectId(mongoose) {
     const { ObjectId } = mongoose.Types;
     const { _id } = data;
 
-    const isValidObjectId = ObjectId.isValid(_id) && new ObjectId(_id).toString() === _id;
-    if (!isValidObjectId) {
+    const isSameObjectId = mongoose.isValidObjectId(_id) && new ObjectId(_id).toString() === _id;
+    if (!isSameObjectId) {
       return data;
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -394,6 +394,18 @@ describe('cachegoose', () => {
       _id: null,
       num: 444,
       str: 'hello'
+    }, {
+      _id: '61e9d74451ffc373968b144e',
+      num: 555,
+      str: 'world'
+    }, {
+      _id: 40549748900222,
+      num: 666,
+      str: 'id out of range'
+    }, {
+      _id: 'abcdefghijklm',
+      num: 777,
+      str: 'id not 12 bytes and not 24 hex chars'
     }];
     await Record.create(records);
     const originalRes = await getAllLean(60);


### PR DESCRIPTION
Sorry for creating another PR, but I've found this issue in my application using the newest version of the lib.

I'm suspecting this is a problem for mongoose 6.x.x, but only tested with 6.1.4. 

The previous snippet works fine with mongoose 5.x.x. Therefore, the issue cannot be reproduced in tests without using mongoose 6.x.x.

Mongoose 5.x.x behaviour:
```
ObjectId.isValid(40549748900222) - true
new ObjectId(40549748900222) - works fine, no exceptions
```

Mongoose 6.x.x behaviour:
```
ObjectId.isValid(40549748900222) - true
new ObjectId(40549748900222) - throws RangeError: The value of "value" is out of range. It must be >= 0 and <= 4294967295. Received 40_549_748_900_222
```

mongoose.isValidObjectId, however, appears to be stricter and consistently returns false for all numbers using both 5.x.x. and 6.x.x. See https://mongoosejs.com/docs/api.html#mongoose_Mongoose-isValidObjectId for more details.

